### PR TITLE
allow to customize create timeout

### DIFF
--- a/wazo_setupd_client/commands/setup.py
+++ b/wazo_setupd_client/commands/setup.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-
 from ..command import SetupdCommand
+
+DEFAULT_TIMEOUT = 60
 
 
 class SetupCommand(SetupdCommand):
@@ -12,6 +13,9 @@ class SetupCommand(SetupdCommand):
     _headers = {'Content-Type': 'application/json',
                 'Accept': 'application/json'}
 
-    def create(self, body):
-        r = self.session.post(self.base_url, json=body, headers=self._headers)
+    def create(self, body, timeout=None):
+        args = {'timeout': DEFAULT_TIMEOUT}
+        if timeout is not None:
+            args['timeout'] = timeout
+        r = self.session.post(self.base_url, json=body, headers=self._headers, **args)
         self.raise_from_response(r)


### PR DESCRIPTION
reason: the 'create' take more time than 'status' or 'config'